### PR TITLE
Fix repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "https://github.com/adfinis-sygroup/ember-autolinker",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/adfinis-sygroup/ember-autolinker"
+  },
   "scripts": {
     "build": "ember build",
     "start": "ember server",


### PR DESCRIPTION
It seems that ember observer can't handle the short form